### PR TITLE
fix: fix `unregister_all` calling `register` internally instead of `unregister`

### DIFF
--- a/.changes/unregister-all-typo.md
+++ b/.changes/unregister-all-typo.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": patch
+---
+
+Fix `GlobalHotKeyManager::unregister_all` actually registering the hotkeys instead of unregistering.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ impl GlobalHotKeyManager {
 
     pub fn unregister_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
         for hotkey in hotkeys {
-            self.register(*hotkey)?;
+            self.unregister(*hotkey)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Calling `GlobalHotKeyManager::unregister_all` actually registers the hot keys because of a typo. This PR fixes it.