### PR TITLE
feat(macOS&linux): add pressed and released states

### DIFF
--- a/examples/tao.rs
+++ b/examples/tao.rs
@@ -4,7 +4,7 @@
 
 use global_hotkey::{
     hotkey::{Code, HotKey, Modifiers},
-    GlobalHotKeyEvent, GlobalHotKeyManager,
+    GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState,
 };
 use tao::event_loop::{ControlFlow, EventLoopBuilder};
 
@@ -29,7 +29,7 @@ fn main() {
         if let Ok(event) = global_hotkey_channel.try_recv() {
             println!("{event:?}");
 
-            if hotkey2.id() == event.id {
+            if hotkey2.id() == event.id && event.state == HotKeyState::Released {
                 hotkeys_manager.unregister(hotkey2).unwrap();
             }
         }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -4,7 +4,7 @@
 
 use global_hotkey::{
     hotkey::{Code, HotKey, Modifiers},
-    GlobalHotKeyEvent, GlobalHotKeyManager,
+    GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState,
 };
 use winit::event_loop::{ControlFlow, EventLoopBuilder};
 
@@ -29,7 +29,7 @@ fn main() {
         if let Ok(event) = global_hotkey_channel.try_recv() {
             println!("{event:?}");
 
-            if hotkey2.id() == event.id {
+            if hotkey2.id() == event.id && event.state == HotKeyState::Released {
                 hotkeys_manager.unregister(hotkey2).unwrap();
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,14 +69,12 @@ pub enum HotKeyState {
     Released,
 }
 
-/// Contains the id of the triggered [`HotKey`] and the state.
 /// Describes a global hotkey event emitted when a [`HotKey`] is pressed or released.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GlobalHotKeyEvent {
     /// Id of the associated [`HotKey`].
     pub id: u32,
     /// State of the associated [`HotKey`].
-    /// The event was triggered by the [`HotKey`] changing to this state.
     pub state: HotKeyState,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,19 @@ mod platform_impl;
 pub use self::error::*;
 use hotkey::HotKey;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HotKeyState {
+    Pressed,
+    Released,
+}
+
 /// Contains the id of the triggered [`HotKey`].
 /// Describes a global hotkey event emitted when a [`HotKey`] is pressed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GlobalHotKeyEvent {
     /// Id of the associated [`HotKey`].
     pub id: u32,
+    pub state: HotKeyState,
 }
 
 /// A reciever that could be used to listen to global hotkey events.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,18 +60,23 @@ mod platform_impl;
 pub use self::error::*;
 use hotkey::HotKey;
 
+/// Describes the state of the [`HotKey`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HotKeyState {
+    /// The [`HotKey`] is pressed (the key is down).  
     Pressed,
+    /// The [`HotKey`] is released (the key is up).  
     Released,
 }
 
-/// Contains the id of the triggered [`HotKey`].
-/// Describes a global hotkey event emitted when a [`HotKey`] is pressed.
+/// Contains the id of the triggered [`HotKey`] and the state.
+/// Describes a global hotkey event emitted when a [`HotKey`] is pressed or released.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GlobalHotKeyEvent {
     /// Id of the associated [`HotKey`].
     pub id: u32,
+    /// State of the associated [`HotKey`].
+    /// The event was triggered by the [`HotKey`] changing to this state.
     pub state: HotKeyState,
 }
 

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -13,6 +13,7 @@ pub type OSType = FourCharCode;
 pub type ByteCount = ::std::os::raw::c_ulong;
 pub type ItemCount = ::std::os::raw::c_ulong;
 pub type OptionBits = UInt32;
+pub type EventKind = UInt32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct OpaqueEventRef {
@@ -63,6 +64,8 @@ pub type _bindgen_ty_1939 = ::std::os::raw::c_uint;
 pub const kEventClassKeyboard: _bindgen_ty_1939 = 1801812322;
 pub type _bindgen_ty_1980 = ::std::os::raw::c_uint;
 pub const kEventHotKeyPressed: _bindgen_ty_1980 = 5;
+pub type _bindgen_ty_1981 = ::std::os::raw::c_uint;
+pub const kEventHotKeyReleased: _bindgen_ty_1981 = 6;
 pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 pub const noErr: _bindgen_ty_1 = 0;
 
@@ -77,7 +80,7 @@ pub struct EventHotKeyID {
 #[derive(Debug, Copy, Clone)]
 pub struct EventTypeSpec {
     pub eventClass: OSType,
-    pub eventKind: UInt32,
+    pub eventKind: EventKind,
 }
 
 #[link(name = "Carbon", kind = "framework")]
@@ -91,6 +94,7 @@ extern "C" {
         outActualSize: *mut ByteCount,
         outData: *mut ::std::os::raw::c_void,
     ) -> OSStatus;
+    pub fn GetEventKind(inEvent: EventRef) -> EventKind;
     pub fn GetApplicationEventTarget() -> EventTargetRef;
     pub fn InstallEventHandler(
         inTarget: EventTargetRef,

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -176,6 +176,7 @@ unsafe extern "C" fn hotkey_handler(
     if result == noErr as _ {
         let _ = GlobalHotKeyEvent::send(GlobalHotKeyEvent {
             id: event_hotkey.id,
+            state: crate::HotKeyState::Pressed,
         });
     }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -139,7 +139,10 @@ unsafe extern "system" fn global_hotkey_subclass_proc(
     _subclass_input_ptr: usize,
 ) -> LRESULT {
     if msg == WM_HOTKEY {
-        GlobalHotKeyEvent::send(GlobalHotKeyEvent { id: wparam as _ });
+        GlobalHotKeyEvent::send(GlobalHotKeyEvent {
+            id: wparam as _,
+            state: crate::HotKeyState::Pressed,
+        });
     }
 
     DefSubclassProc(hwnd, msg, wparam, lparam)

--- a/src/platform_impl/x11/mod.rs
+++ b/src/platform_impl/x11/mod.rs
@@ -94,10 +94,17 @@ fn events_processor(thread_rx: Receiver<ThreadMessage>) {
                             if let Some((id, repeating)) = hotkeys.get_mut(&(modifiers, keycode)) {
                                 match (e, *repeating) {
                                     (xlib::KeyPress, false) => {
-                                        GlobalHotKeyEvent::send(GlobalHotKeyEvent { id: *id });
+                                        GlobalHotKeyEvent::send(GlobalHotKeyEvent {
+                                            id: *id,
+                                            state: crate::HotKeyState::Pressed,
+                                        });
                                         *repeating = true;
                                     }
                                     (xlib::KeyRelease, true) => {
+                                        GlobalHotKeyEvent::send(GlobalHotKeyEvent {
+                                            id: *id,
+                                            state: crate::HotKeyState::Released,
+                                        });
                                         *repeating = false;
                                     }
                                     _ => {}


### PR DESCRIPTION
I've had look into Issue #9: separate press and release key events.

Status:

- Macos: Tested (on arm64) and seems to work correctly.  
- Linux: Untested, but the existing logic seems sound to just add to.
- Windows:  Not implemented. AFAIK you don't get a keyup (via WM_HOTKEY) but an approach is to repeatedly check the state of each previously key. (I guess not dissimilar to the X11 version). So you only have Pressed events on Windows at the min

I've implemented the `pub state` as suggested in the issue, but that means existing apps will get two events when they are expecting one.

See #9.