### PR TITLE
perf: improve `un/register_all` performance on Linux

### DIFF
--- a/.changes/un-register-all-perf-linux.md
+++ b/.changes/un-register-all-perf-linux.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": "patch"
+---
+
+On Linux, improve the performance of `GlobalHotKeyManager::register_all` and `GlobalHotKeyManager::unregister_all` to 2711x faster.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,16 +150,12 @@ impl GlobalHotKeyManager {
     }
 
     pub fn register_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
-        for hotkey in hotkeys {
-            self.register(*hotkey)?;
-        }
+        self.platform_impl.register_all(hotkeys)?;
         Ok(())
     }
 
     pub fn unregister_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
-        for hotkey in hotkeys {
-            self.unregister(*hotkey)?;
-        }
+        self.platform_impl.unregister_all(hotkeys)?;
         Ok(())
     }
 }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -131,10 +131,16 @@ impl GlobalHotKeyManager {
         Ok(())
     }
 
-    pub fn unregister_all(&self) -> crate::Result<()> {
-        let hotkeys = self.hotkeys.lock().unwrap().clone();
-        for (_, hotkeywrapper) in hotkeys {
-            self.unregister(hotkeywrapper.hotkey)?;
+    pub fn register_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
+        for hotkey in hotkeys {
+            self.register(*hotkey)?;
+        }
+        Ok(())
+    }
+
+    pub fn unregister_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
+        for hotkey in hotkeys {
+            self.unregister(*hotkey)?;
         }
         Ok(())
     }
@@ -154,7 +160,10 @@ impl GlobalHotKeyManager {
 
 impl Drop for GlobalHotKeyManager {
     fn drop(&mut self) {
-        let _ = self.unregister_all();
+        let hotkeys = self.hotkeys.lock().unwrap().clone();
+        for (_, hotkeywrapper) in hotkeys {
+            let _ = self.unregister(hotkeywrapper.hotkey);
+        }
         unsafe {
             RemoveEventHandler(self.event_handler_ptr);
         }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -116,6 +116,20 @@ impl GlobalHotKeyManager {
         }
         Ok(())
     }
+
+    pub fn register_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
+        for hotkey in hotkeys {
+            self.register(*hotkey)?;
+        }
+        Ok(())
+    }
+
+    pub fn unregister_all(&self, hotkeys: &[HotKey]) -> crate::Result<()> {
+        for hotkey in hotkeys {
+            self.unregister(*hotkey)?;
+        }
+        Ok(())
+    }
 }
 unsafe extern "system" fn global_hotkey_proc(
     hwnd: HWND,


### PR DESCRIPTION
closes #33

pr: 464.645µs
dev branch: 1.259750603s

by passing the hotkeys in one go and registering all of them at once, we get 2711x faster