### PR TITLE
fix: always process all events in the queue on x11.

### DIFF
--- a/.changes/x11-pending-events-buildup.md
+++ b/.changes/x11-pending-events-buildup.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": patch
+---
+
+Always service all pending events to avoid a queue of events from building up.

--- a/src/platform_impl/x11/mod.rs
+++ b/src/platform_impl/x11/mod.rs
@@ -199,7 +199,8 @@ fn events_processor(thread_rx: Receiver<ThreadMessage>) {
             let mut event: xlib::XEvent = std::mem::zeroed();
 
             loop {
-                if (xlib.XPending)(display) > 0 {
+                // Always service all pending events to avoid a queue of events from building up.
+                while (xlib.XPending)(display) > 0 {
                     (xlib.XNextEvent)(display, &mut event);
                     match event.get_type() {
                         e @ xlib::KeyPress | e @ xlib::KeyRelease => {


### PR DESCRIPTION
#### Commit message:
> Previously, there was always a 50ms delay between processing individual events, which could lead to a queue of events building up if the key repeat was higher than 20 Hz. This resulted in the global hotkey release only being detected long after the key is released.

#### Extra information:
Holding the key for a longer duration led to a larger backlog, and thus a longer delay before the release event was detected. I opted for the `while` solution instead of reducing the sleep to ensure we always clear out the entire event backlog. 

The 50ms delay here does still mean that we incur a worst case delay of 50ms when detecting the keydown and keyup event. I looked for a version of `XNextEvent` with a timeout and I found [this article](https://nrk.neocities.org/articles/x11-timeout-with-xsyncalarm) that describes two approaches to check for events with a timeout, the first requires using `poll`, the second sets an `XSyncAlarm` to break out of the blocking `XNextEvent` call. It add significant complexity, so I don't think the trade off is worth it at this moment.
