### PR TITLE
Migrate from `objc` to `objc2`

### DIFF
--- a/.changes/use-objc2.md
+++ b/.changes/use-objc2.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": patch
+---
+
+Use `objc2` internally, leading to slightly better memory- and type-safety.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,29 +3,28 @@ name = "global-hotkey"
 version = "0.6.0"
 description = "Global hotkeys for Desktop Applications"
 edition = "2021"
-keywords = [ "windowing", "global", "global-hotkey", "hotkey" ]
+keywords = ["windowing", "global", "global-hotkey", "hotkey"]
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 repository = "https://github.com/amrbashir/global-hotkey"
 documentation = "https://docs.rs/global-hotkey"
-categories = [ "gui" ]
+categories = ["gui"]
 
 [features]
-serde = [ "dep:serde" ]
+serde = ["dep:serde"]
 
 [dependencies]
 crossbeam-channel = "0.5"
 keyboard-types = "0.7"
 once_cell = "1"
 thiserror = "1"
-serde = { version = "1", optional = true, features = [ "derive" ] }
+serde = { version = "1", optional = true, features = ["derive"] }
 
-[target."cfg(target_os = \"macos\")".dependencies]
-bitflags = "2"
-cocoa = "0.26"
-objc = "0.2"
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.5.2"
+objc2-app-kit = { version = "0.2.2", features = ["NSEvent"] }
 
-[target."cfg(target_os = \"windows\")".dependencies.windows-sys]
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.59"
 features = [
   "Win32_UI_WindowsAndMessaging",
@@ -33,10 +32,10 @@ features = [
   "Win32_System_SystemServices",
   "Win32_Graphics_Gdi",
   "Win32_UI_Shell",
-  "Win32_UI_Input_KeyboardAndMouse"
+  "Win32_UI_Input_KeyboardAndMouse",
 ]
 
-[target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 x11-dl = "2.21"
 
 [dev-dependencies]

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -7,6 +7,8 @@
 
 use std::ffi::{c_long, c_void};
 
+use objc2::encode::{Encode, Encoding, RefEncode};
+
 pub type UInt32 = ::std::os::raw::c_uint;
 pub type SInt32 = ::std::os::raw::c_int;
 pub type OSStatus = SInt32;
@@ -198,6 +200,10 @@ macro_rules! CGEventMaskBit {
 
 pub enum CGEvent {}
 pub type CGEventRef = *const CGEvent;
+
+unsafe impl RefEncode for CGEvent {
+    const ENCODING_REF: Encoding = Encoding::Pointer(&Encoding::Struct("__CGEvent", &[]));
+}
 
 pub type CGEventTapProxy = *const c_void;
 type CGEventTapCallBack = unsafe extern "C" fn(


### PR DESCRIPTION
See https://github.com/tauri-apps/wry/issues/1239 and backreferences to https://github.com/madsmtm/objc2/issues/174 for context and details.

Not really that important for this crate (yet), since it mostly uses CoreGraphics, but still improves type-safety a little bit.