### PR TITLE
enhance: pack mods & key into a u32 as id instead of hashing

### DIFF
--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -55,7 +55,7 @@ pub struct HotKey {
     /// The hotkey key.
     pub key: Code,
     /// The hotkey id.
-    pub id: u32,
+    pub id: u64,
 }
 
 #[cfg(feature = "serde")]
@@ -92,20 +92,13 @@ impl HotKey {
         }
 
         let mut hotkey = Self { mods, key, id: 0 };
-        hotkey.id = hotkey.generate_hash();
+        hotkey.id = (mods.bits() as u64) << 32 | key as u64;
         hotkey
-    }
-
-    fn generate_hash(&self) -> u32 {
-        let hotkey_str = self.into_string();
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        hotkey_str.hash(&mut hasher);
-        std::hash::Hasher::finish(&hasher) as u32
     }
 
     /// Returns the id associated with this hotKey
     /// which is a hash of the string represention of modifiers and key within this hotKey.
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> u64 {
         self.id
     }
 

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -91,7 +91,11 @@ impl HotKey {
             mods.insert(Modifiers::SUPER);
         }
 
-        Self { mods, key, id: (mods.bits() as u32) << 16 | key as u32}
+        Self {
+            mods,
+            key,
+            id: mods.bits() << 16 | key as u32,
+        }
     }
 
     /// Returns the id associated with this hotKey

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -55,7 +55,7 @@ pub struct HotKey {
     /// The hotkey key.
     pub key: Code,
     /// The hotkey id.
-    pub id: u64,
+    pub id: u32,
 }
 
 #[cfg(feature = "serde")]
@@ -91,14 +91,12 @@ impl HotKey {
             mods.insert(Modifiers::SUPER);
         }
 
-        let mut hotkey = Self { mods, key, id: 0 };
-        hotkey.id = (mods.bits() as u64) << 32 | key as u64;
-        hotkey
+        Self { mods, key, id: (mods.bits() as u32) << 16 | key as u32}
     }
 
     /// Returns the id associated with this hotKey
     /// which is a hash of the string represention of modifiers and key within this hotKey.
-    pub fn id(&self) -> u64 {
+    pub fn id(&self) -> u32 {
         self.id
     }
 


### PR DESCRIPTION
Change mentioned in #101.