### PR TITLE
fix(linux): Use c_ulong for ffi calls instead of u64

### DIFF
--- a/.changes/fix-linux-32bit.md
+++ b/.changes/fix-linux-32bit.md
@@ -1,0 +1,5 @@
+---
+global-hotkey: patch
+---
+
+Fixed an issue causing compilation to fail for 32-bit targets.

--- a/src/platform_impl/x11/mod.rs
+++ b/src/platform_impl/x11/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::{collections::BTreeMap, ptr};
+use std::{collections::BTreeMap, ffi::c_ulong, ptr};
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use keyboard_types::{Code, Modifiers};
@@ -105,7 +105,7 @@ const IGNORED_MODS: [u32; 4] = [
 fn register_hotkey(
     xlib: &Xlib,
     display: *mut _XDisplay,
-    root: u64,
+    root: c_ulong,
     hotkeys: &mut BTreeMap<u32, Vec<(u32, u32, bool)>>,
     hotkey: HotKey,
 ) -> crate::Result<()> {
@@ -159,7 +159,7 @@ fn register_hotkey(
 fn unregister_hotkey(
     xlib: &Xlib,
     display: *mut _XDisplay,
-    root: u64,
+    root: c_ulong,
     hotkeys: &mut BTreeMap<u32, Vec<(u32, u32, bool)>>,
     hotkey: HotKey,
 ) -> crate::Result<()> {
@@ -189,7 +189,7 @@ fn events_processor(thread_rx: Receiver<ThreadMessage>) {
     if let Ok(xlib) = xlib::Xlib::open() {
         unsafe {
             let display = (xlib.XOpenDisplay)(ptr::null());
-            let root = (xlib.XDefaultRootWindow)(display);
+            let root: c_ulong = (xlib.XDefaultRootWindow)(display);
 
             // Only trigger key release at end of repeated keys
             let mut supported_rtrn: i32 = 0;


### PR DESCRIPTION
fixes #105 - note that i didn't test this in an actual app but `cargo check --target ...` stopped complained with these changes. It's also similar to my Wry [change](https://github.com/tauri-apps/wry/commit/3e84a0e276dfac0b28fb01f42460f9367fff9f22) a while ago that seemingly was fine.