### PR TITLE
chore: prepare for `objc2` frameworks v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,10 @@ serde = { version = "1", optional = true, features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.2"
-objc2-app-kit = { version = "0.2.2", features = ["NSEvent"] }
+objc2-app-kit = { version = "0.2.2", default-features = false, features = [
+  "std",
+  "NSEvent",
+] }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.59"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,8 @@ impl GlobalHotKeyEvent {
     pub fn id(&self) -> u32 {
         self.id
     }
-    /// Returns the state of the associated [`HotKey`].
 
+    /// Returns the state of the associated [`HotKey`].
     pub fn state(&self) -> HotKeyState {
         self.state
     }


### PR DESCRIPTION
The next version of the `objc2-app-kit` crate will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).

I did not include a changelog entry here, since there are no user-facing changes, and since it doesn't need to be shipped to users.