### PR TITLE
Fix hotkey registration crashing winit if hotkey is already bound by another application on X11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["gui"]
 
 [features]
 serde = ["dep:serde"]
+winit = ["dep:winit"]
 
 [dependencies]
 crossbeam-channel = "0.5"
@@ -37,10 +38,26 @@ features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 x11-dl = "2.21"
+winit = { version = "0.30", optional = true }
 
 [dev-dependencies]
-winit = "0.29"
+winit = "0.30"
 tao = "0.30"
 eframe = "0.27"
 iced = "0.12.1"
 async-std = "1.12.0"
+
+[[example]]
+name = "iced"
+path = "examples/iced.rs"
+required-features = ["winit"]
+
+[[example]]
+name = "egui"
+path = "examples/egui.rs"
+required-features = ["winit"]
+
+[[example]]
+name = "winit"
+path = "examples/winit.rs"
+required-features = ["winit"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ global_hotkey lets you register Global HotKeys for Desktop Applications.
 
 - On Windows a win32 event loop must be running on the thread. It doesn't need to be the main thread but you have to create the global hotkey manager on the same thread as the event loop.
 - On macOS, an event loop must be running on the main thread so you also need to create the global hotkey manager on the main thread.
+- On Linux X11, if attempted to register a hotkey which is already registered by another application, the error will be reported on process-wide Xlib error handler, more information: https://www.remlab.net/op/xlib.shtml
+  - For winit, `winit` feature is available which captures global error and properly returns it in `register()` response Result, otherwise the error will result in panic in unrelated place
 
 ## Example
 

--- a/src/platform_impl/x11/mod.rs
+++ b/src/platform_impl/x11/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::{collections::BTreeMap, ffi::c_ulong, ptr};
+use std::{collections::BTreeMap, ffi::c_ulong, ptr, sync::Mutex};
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use keyboard_types::{Code, Modifiers};
@@ -101,6 +101,12 @@ const IGNORED_MODS: [u32; 4] = [
     xlib::Mod2Mask | xlib::LockMask,
 ];
 
+struct XlibError {
+    error_code: std::ffi::c_uchar,
+}
+
+static XLIB_ERROR: Mutex<Option<XlibError>> = Mutex::new(None);
+
 #[inline]
 fn register_hotkey(
     xlib: &Xlib,
@@ -129,6 +135,22 @@ fn register_hotkey(
                     xlib::GrabModeAsync,
                 )
             };
+
+            unsafe {
+                (xlib.XSync)(display, 0);
+            }
+
+            let error = XLIB_ERROR.lock().expect("lock is poisoned").take();
+
+            if let Some(error) = error {
+                if error.error_code == xlib::BadAccess {
+                    for m in IGNORED_MODS {
+                        unsafe { (xlib.XUngrabKey)(display, keycode as _, modifiers | m, root) };
+                    }
+
+                    return Err(crate::Error::AlreadyRegistered(hotkey));
+                }
+            }
 
             if result == xlib::BadAccess as _ {
                 for m in IGNORED_MODS {
@@ -190,6 +212,23 @@ fn events_processor(thread_rx: Receiver<ThreadMessage>) {
         unsafe {
             let display = (xlib.XOpenDisplay)(ptr::null());
             let root: c_ulong = (xlib.XDefaultRootWindow)(display);
+
+            #[cfg(feature = "winit")]
+            winit::platform::x11::register_xlib_error_hook(Box::new(|_display, error| {
+                let error_event = *(error as *mut xlib::XErrorEvent);
+
+                // 33 is XGrabKey
+                if error_event.request_code == 33 {
+                    let mut error = XLIB_ERROR.lock().expect("lock is poisoned");
+                    *error = Some(XlibError {
+                        error_code: error_event.error_code,
+                    });
+
+                    true
+                } else {
+                    false
+                }
+            }));
 
             // Only trigger key release at end of repeated keys
             let mut supported_rtrn: i32 = 0;


### PR DESCRIPTION
Fixes https://github.com/tauri-apps/global-hotkey/issues/140

More information: https://github.com/rust-windowing/winit/issues/2378

The fix works but there are couple of things that could be improved, but global hotkey registration is rare enough thing that it shouldn't be a problem

- The display is not checked, so by itself it may catch error from different display, but winit and this crate use `XOpenDisplay` to get display so it shouldn't be an issue if i understand correctly
- There may be a race condition if 2 registrations on different threads are attempted at the same time, error from one thread might be picked up by another so one error will be lost. While it may be fixed, I don't think it is feasible, due to usage of Xlib there probably a lot more multi-threading issues, it may be better to just migrate away from Xlib