### PR TITLE
Update minimum supported Rust version to 1.77

### DIFF
--- a/.changes/msrv.md
+++ b/.changes/msrv.md
@@ -1,0 +1,5 @@
+---
+global-hotkey: minor
+---
+
+Increased MSRV to `1.77`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libxdo-dev
 
-      - uses: dtolnay/rust-toolchain@1.71
+      - uses: dtolnay/rust-toolchain@1.77
       - run: cargo build
 
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/tauri-apps/global-hotkey"
 documentation = "https://docs.rs/global-hotkey"
 categories = ["gui"]
-rust-version = "1.71"
+rust-version = "1.77"
 
 [features]
 serde = ["dep:serde"]


### PR DESCRIPTION
This PR updates the minimum supported Rust version (MSRV) from **1.71 to 1.80**.

Many dependencies in this crate — including those required for upcoming Wayland support — no longer compile on Rust versions earlier than 1.77.
By raising the MSRV to 1.80, we ensure compatibility with current ecosystem crates and upcoming features.

This change is also a prerequisite for https://github.com/tauri-apps/global-hotkey/pull/162, which introduces Wayland support using the **XDG GlobalShortcuts portal**.
That PR cannot be merged until the MSRV is updated, since its dependencies and related APIs require Rust ≥ 1.77.

> [!NOTE]
> We will probably also need to update Cargo.lock 🤔

- [x] Cargo check works fine with that change