### PR TITLE
Use HWND_MESSAGE as parent on Windows

### DIFF
--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -11,8 +11,7 @@ use windows_sys::Win32::{
         Input::KeyboardAndMouse::*,
         WindowsAndMessaging::{
             CreateWindowExW, DefWindowProcW, DestroyWindow, RegisterClassW, CW_USEDEFAULT,
-            WM_HOTKEY, WNDCLASSW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
-            WS_EX_TRANSPARENT, WS_OVERLAPPED,
+            HWND_MESSAGE, WM_HOTKEY, WNDCLASSW,
         },
     },
 };
@@ -45,23 +44,17 @@ impl GlobalHotKeyManager {
             RegisterClassW(&wnd_class);
 
             let hwnd = CreateWindowExW(
-                WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED |
-                // WS_EX_TOOLWINDOW prevents this window from ever showing up in the taskbar, which
-                // we want to avoid. If you remove this style, this window won't show up in the
-                // taskbar *initially*, but it can show up at some later point. This can sometimes
-                // happen on its own after several hours have passed, although this has proven
-                // difficult to reproduce. Alternatively, it can be manually triggered by killing
-                // `explorer.exe` and then starting the process back up.
-                // It is unclear why the bug is triggered by waiting for several hours.
-                WS_EX_TOOLWINDOW,
+                // not required for HWND_MESSAGE
+                0,
                 class_name.as_ptr(),
                 ptr::null(),
-                WS_OVERLAPPED,
-                CW_USEDEFAULT,
+                // not required for HWND_MESSAGE
                 0,
                 CW_USEDEFAULT,
                 0,
-                std::ptr::null_mut(),
+                CW_USEDEFAULT,
+                0,
+                HWND_MESSAGE,
                 std::ptr::null_mut(),
                 hinstance,
                 std::ptr::null_mut(),


### PR DESCRIPTION
Switches the Windows impl to use a [Message-Only Window](https://learn.microsoft.com/en-us/windows/win32/winmsg/window-features#message-only-windows).

As before, the window will not appear in the taskbar or window switcher and there's no risk of it randomly (which was a rather amusing note to read while figuring out what I needed to change!) becoming visible to the user.

This should also improve compatibility with certain classes of apps on Windows. 

My use case for this change was that I'm building a small screenshot utility using `tauri-plugin-global-shortcut` and noticed that some fullscreen apps (namely, games with anticheat) were interfering with hotkey activation. After switching to a message only window, I've been able to receive input with an anticheat protected game in the foreground whereas before I was getting nothing.