### PR TITLE
fix(windows): add sleep in release-detection loop to reduce CPU usage

### DIFF
--- a/.changes/windows-release-poll-sleep.md
+++ b/.changes/windows-release-poll-sleep.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": patch
+---
+
+On Windows, sleep 50ms in the release-detection loop to avoid burning a CPU core for the whole hold duration (e.g. push-to-talk).

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -163,6 +163,10 @@ unsafe extern "system" fn global_hotkey_proc(
                 });
                 break;
             }
+            // Sleep to avoid burning a core for the whole hold duration
+            // (e.g. push-to-talk). 50ms keeps release latency imperceptible.
+            // See https://github.com/tauri-apps/global-hotkey/issues/176
+            std::thread::sleep(std::time::Duration::from_millis(50));
         });
     }
 


### PR DESCRIPTION
fixes #176