### PR TITLE
fix(windows): use VK_CANCEL to register Ctrl+Pause

### DIFF
--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -92,15 +92,15 @@ impl GlobalHotKeyManager {
         // get key scan code
         match key_to_vk(&hotkey.key) {
             Some(vk_code) => {
-                let vk_code = if hotkey.key == Code::Pause && hotkey.mods.contains(Modifiers::CONTROL)
-                {
-                    // On Windows, Ctrl+Pause is exposed as Break/Control-Break (`VK_CANCEL`)
-                    // rather than `VK_PAUSE`, but the control modifier still participates in the
-                    // hotkey chord.
-                    VK_CANCEL
-                } else {
-                    vk_code
-                };
+                let vk_code =
+                    if hotkey.key == Code::Pause && hotkey.mods.contains(Modifiers::CONTROL) {
+                        // On Windows, Ctrl+Pause is exposed as Break/Control-Break (`VK_CANCEL`)
+                        // rather than `VK_PAUSE`, but the control modifier still participates in the
+                        // hotkey chord.
+                        VK_CANCEL
+                    } else {
+                        vk_code
+                    };
 
                 let result =
                     unsafe { RegisterHotKey(self.hwnd, hotkey.id() as _, mods, vk_code as _) };

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -92,6 +92,16 @@ impl GlobalHotKeyManager {
         // get key scan code
         match key_to_vk(&hotkey.key) {
             Some(vk_code) => {
+                let vk_code = if hotkey.key == Code::Pause && hotkey.mods.contains(Modifiers::CONTROL)
+                {
+                    // On Windows, Ctrl+Pause is exposed as Break/Control-Break (`VK_CANCEL`)
+                    // rather than `VK_PAUSE`, but the control modifier still participates in the
+                    // hotkey chord.
+                    VK_CANCEL
+                } else {
+                    vk_code
+                };
+
                 let result =
                     unsafe { RegisterHotKey(self.hwnd, hotkey.id() as _, mods, vk_code as _) };
                 if result == 0 {


### PR DESCRIPTION
On Windows, Ctrl+Pause is exposed by the system as VK_CANCEL rather than VK_PAUSE.

This change updates Windows hotkey registration to handle that case correctly by registering Code::Pause with VK_CANCEL when Modifiers::CONTROL is present, while keeping the control modifier in the hotkey chord.

Result: Ctrl+Pause and Ctrl+PauseBreak now register correctly on Windows without changing the library’s public hotkey model.