### PR TITLE
fix(x11): flush connection after ungrab_key so unregister takes effect immediately

### DIFF
--- a/.changes/x11-flush-ungrab.md
+++ b/.changes/x11-flush-ungrab.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": "patch"
+---
+
+On X11, flush the connection after `ungrab_key` in `unregister_hotkey` so the ungrab takes effect immediately. Previously the ungrab request stayed buffered (the event loop polls but never flushes, and unlike `register` there is no `check()` round-trip to flush implicitly), leaving the key grabbed system-wide until the next request that waits for a reply.

--- a/src/platform_impl/x11/mod.rs
+++ b/src/platform_impl/x11/mod.rs
@@ -160,6 +160,8 @@ fn register_hotkey(
                                 result.ignore_error();
                             }
                         }
+                        // Flush the rollback ungrabs (see unregister_hotkey).
+                        let _ = conn.flush();
 
                         Err(Error::AlreadyRegistered(hotkey))
                     } else {
@@ -212,6 +214,14 @@ fn unregister_hotkey(
             result.ignore_error();
         }
     }
+
+    // Flush so the ungrab actually reaches the X server. `ungrab_key` only
+    // queues the request, and the event loop polls with `poll_for_event`,
+    // which does not flush outgoing requests. `register_hotkey` flushes
+    // implicitly via `grab_key(..).check()`, but unregister has no such
+    // round-trip, so without this flush the key stays grabbed system-wide
+    // until the next request that waits for a reply (e.g. the next register).
+    let _ = conn.flush();
 
     let entry = hotkeys.entry(keycode).or_default();
     entry.retain(|k| k.mods != modifiers);


### PR DESCRIPTION
## Problem

On X11, unregistering a hotkey does not actually release the grab until some
later, unrelated request happens to flush the connection.

`unregister_hotkey` issues `ungrab_key(..).ignore_error()` but never flushes,
and the event loop drives the connection with `poll_for_event`, which reads
incoming events but does not flush outgoing requests. `register_hotkey` happens
to flush implicitly because `grab_key(..).check()` waits for a reply (a round
trip), so grabs apply immediately — but `unregister` has no such round trip, so
the `XUngrabKey` requests sit buffered.

The result: a key stays grabbed system-wide between `unregister` and the next
request that flushes (typically the next `register`), even though
`GlobalHotKeyManager::is_registered` / the public API report it as unregistered.
Downstream this shows up as a hotkey that keeps being swallowed globally after
the app thinks it released it.

## Repro

1. `register` a hotkey (e.g. `Escape`).
2. `unregister` it.
3. Press the key in another application — it's still swallowed (the passive grab
   is still active at the X server) until another `register` call is made.

## Fix

Add `conn.flush()` after the ungrab loop in `unregister_hotkey`, and after the
rollback ungrabs in `register_hotkey`'s already-registered error path.

Only affects the Linux/X11 backend; no API change.