### PR TITLE
chore(deps): Upgrade to keyboard-types v0.8

### DIFF
--- a/.changes/keyboard-types-0.8.md
+++ b/.changes/keyboard-types-0.8.md
@@ -1,0 +1,5 @@
+---
+"global-hotkey": minor
+---
+
+Upgrade `keyboard-types` to 0.8 and use `META` as the primary variant for the Super modifier.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,9 +620,6 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block"
@@ -2848,13 +2845,12 @@ dependencies = [
 
 [[package]]
 name = "keyboard-types"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
 dependencies = [
  "bitflags 2.8.0",
  "serde",
- "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 crossbeam-channel = "0.5"
-keyboard-types = "0.7"
+keyboard-types = "0.8"
 once_cell = "1"
 thiserror = "2"
 serde = { version = "1", optional = true, features = ["derive"] }

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -31,7 +31,7 @@ pub use keyboard_types::{Code, Modifiers};
 use std::{borrow::Borrow, fmt::Display, hash::Hash, str::FromStr};
 
 #[cfg(target_os = "macos")]
-pub const CMD_OR_CTRL: Modifiers = Modifiers::SUPER;
+pub const CMD_OR_CTRL: Modifiers = Modifiers::META;
 #[cfg(not(target_os = "macos"))]
 pub const CMD_OR_CTRL: Modifiers = Modifiers::CONTROL;
 
@@ -83,12 +83,14 @@ impl serde::Serialize for HotKey {
 
 impl HotKey {
     /// Creates a new hotkey to define keyboard shortcuts throughout your application.
-    /// Only [`Modifiers::ALT`], [`Modifiers::SHIFT`], [`Modifiers::CONTROL`], and [`Modifiers::SUPER`]
+    /// Only [`Modifiers::ALT`], [`Modifiers::SHIFT`], [`Modifiers::CONTROL`], and [`Modifiers::META`]
     pub fn new(mods: Option<Modifiers>, key: Code) -> Self {
         let mut mods = mods.unwrap_or_else(Modifiers::empty);
-        if mods.contains(Modifiers::META) {
-            mods.remove(Modifiers::META);
-            mods.insert(Modifiers::SUPER);
+
+        #[allow(deprecated)]
+        if mods.contains(Modifiers::SUPER) {
+            mods.remove(Modifiers::SUPER);
+            mods.insert(Modifiers::META);
         }
 
         Self {
@@ -107,7 +109,7 @@ impl HotKey {
     /// Returns `true` if this [`Code`] and [`Modifiers`] matches this hotkey.
     pub fn matches(&self, modifiers: impl Borrow<Modifiers>, key: impl Borrow<Code>) -> bool {
         // Should be a const but const bit_or doesn't work here.
-        let base_mods = Modifiers::SHIFT | Modifiers::CONTROL | Modifiers::ALT | Modifiers::SUPER;
+        let base_mods = Modifiers::SHIFT | Modifiers::CONTROL | Modifiers::ALT | Modifiers::META;
         let modifiers = modifiers.borrow();
         let key = key.borrow();
         self.mods == *modifiers & base_mods && self.key == *key
@@ -125,8 +127,8 @@ impl HotKey {
         if self.mods.contains(Modifiers::ALT) {
             hotkey.push_str("alt+")
         }
-        if self.mods.contains(Modifiers::SUPER) {
-            hotkey.push_str("super+")
+        if self.mods.contains(Modifiers::META) {
+            hotkey.push_str("meta+")
         }
         hotkey.push_str(&self.key.to_string());
         hotkey
@@ -202,15 +204,15 @@ fn parse_hotkey(hotkey: &str) -> Result<HotKey, HotKeyParseError> {
                     "CONTROL" | "CTRL" => {
                         mods |= Modifiers::CONTROL;
                     }
-                    "COMMAND" | "CMD" | "SUPER" => {
-                        mods |= Modifiers::SUPER;
+                    "COMMAND" | "CMD" | "SUPER" | "META" => {
+                        mods |= Modifiers::META;
                     }
                     "SHIFT" => {
                         mods |= Modifiers::SHIFT;
                     }
                     #[cfg(target_os = "macos")]
                     "COMMANDORCONTROL" | "COMMANDORCTRL" | "CMDORCTRL" | "CMDORCONTROL" => {
-                        mods |= Modifiers::SUPER;
+                        mods |= Modifiers::META;
                     }
                     #[cfg(not(target_os = "macos"))]
                     "COMMANDORCONTROL" | "COMMANDORCTRL" | "CMDORCTRL" | "CMDORCONTROL" => {
@@ -403,9 +405,9 @@ fn test_parse_hotkey() {
     );
 
     assert_parse_hotkey!(
-        "super+ctrl+SHIFT+alt+ArrowUp",
+        "meta+ctrl+SHIFT+alt+ArrowUp",
         HotKey {
-            mods: Modifiers::SUPER | Modifiers::CONTROL | Modifiers::SHIFT | Modifiers::ALT,
+            mods: Modifiers::META | Modifiers::CONTROL | Modifiers::SHIFT | Modifiers::ALT,
             key: Code::ArrowUp,
             id: 0,
         }
@@ -440,7 +442,7 @@ fn test_parse_hotkey() {
         "CmdOrCtrl+Space",
         HotKey {
             #[cfg(target_os = "macos")]
-            mods: Modifiers::SUPER,
+            mods: Modifiers::META,
             #[cfg(not(target_os = "macos"))]
             mods: Modifiers::CONTROL,
             key: Code::Space,

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -85,6 +85,7 @@ impl GlobalHotKeyManager {
         if hotkey.mods.contains(Modifiers::SHIFT) {
             mods |= 512;
         }
+        #[allow(deprecated)]
         if hotkey.mods.intersects(Modifiers::SUPER | Modifiers::META) {
             mods |= 256;
         }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -79,6 +79,7 @@ impl GlobalHotKeyManager {
         if hotkey.mods.contains(Modifiers::SHIFT) {
             mods |= MOD_SHIFT;
         }
+        #[allow(deprecated)]
         if hotkey.mods.intersects(Modifiers::SUPER | Modifiers::META) {
             mods |= MOD_WIN;
         }

--- a/src/platform_impl/x11/mod.rs
+++ b/src/platform_impl/x11/mod.rs
@@ -452,6 +452,7 @@ fn modifiers_to_x11_mods(modifiers: Modifiers) -> ModMask {
     if modifiers.contains(Modifiers::SHIFT) {
         x11mods |= ModMask::SHIFT;
     }
+    #[allow(deprecated)]
     if modifiers.intersects(Modifiers::SUPER | Modifiers::META) {
         x11mods |= ModMask::M4;
     }


### PR DESCRIPTION
- Bump version requirement
- Switch from `SUPER` to `META` as the primary variant for that key (`SUPER` has been deprecated in 0.8)